### PR TITLE
fix: set cedar_ve2 to uaccess

### DIFF
--- a/debian/libgstreamer-openmax-allwinner.sunxi-ve.udev
+++ b/debian/libgstreamer-openmax-allwinner.sunxi-ve.udev
@@ -1,2 +1,3 @@
 ACTION=="add" SUBSYSTEM=="dma_heap" KERNEL=="system" TAG+="uaccess"
 ACTION=="add" SUBSYSTEM=="cedar_ve" TAG+="uaccess"
+ACTION=="add" SUBSYSTEM=="cedar_ve2" TAG+="uaccess"


### PR DESCRIPTION
Allow non-privileged users to use the A733 hardware decoding