### PR TITLE
fix: pkg.conf: remove xserver-xorg-img-bxm

### DIFF
--- a/pkg.conf
+++ b/pkg.conf
@@ -8,5 +8,8 @@
       "a733-bullseye",
       "a733-bullseye-test"
     ]
+  },
+  "xserver-xorg-img-bxm_1.21.1-2_arm64.deb": {
+    "Releases": []
   }
 }


### PR DESCRIPTION
Prioritize using the xserver-xorg-img-bxm from allwinner-prebuilt-extra